### PR TITLE
Support for an enabled/disabled state flag and associated tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ By default, the save button is labeled 'Save'. You can change that easily:
     onSave='changeValue'}}
 ```
 
+Editing can be conditionally prevented with the `enabled` property. When the component becomes disabled, the `onClose` event will be fired.
+
+```handlebars
+  {{ember-inline-edit
+    value=value
+    enabled=session.isAuthenticated
+    onSave='changeValue'}}
+```
+
 There's no styling provided by default. Feel free to add your own.
 
 #### Keyboard Support

--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
   textAreaFields: ['textarea'],
 
   isEditing: false,
-
+  enabled: true,
   field: 'text',
   value: null,
   placeholder: 'Not Provided',
@@ -45,17 +45,20 @@ export default Ember.Component.extend({
 
   _handleClick (e) {
     const isEditing = get(this, 'isEditing')
+    const enabled = get(this, 'enabled')
     const editor = Ember.$(this.element)
     const target = Ember.$(e.target)
     const isInside = editor.is(target) || editor.has(target).length > 0
 
-    if (isInside && !isEditing) {
-      if (get(this, 'showEditButton')) { return }
-      let width = Ember.String.htmlSafe('width: ' + (editor.width() + 2) + 'px')
-      Ember.run(this, function(){ this.set('fieldWidth', width)})
-      this.send('startEditing', e)
-    } else if (!isInside && isEditing) {
-      this.send('close')
+    if(enabled) {
+      if (isInside && !isEditing) {
+        if (get(this, 'showEditButton')) { return }
+        let width = Ember.String.htmlSafe('width: ' + (editor.width() + 2) + 'px')
+        Ember.run(this, function(){ this.set('fieldWidth', width)})
+        this.send('startEditing', e)
+      } else if (!isInside && isEditing) {
+        this.send('close')
+      }
     }
   },
 
@@ -74,12 +77,18 @@ export default Ember.Component.extend({
   },
 
   _focusOnInput () {
-    run.next(() => { Ember.$('.ember-inline-edit-input').focus() })
+    run.next(() => { Ember.$(this.element).find('.ember-inline-edit-input').focus() })
   },
 
   _teardown: on('willDestroyElement', function() {
     Ember.$(document).off('click', this._handleClick)
     Ember.$(this.element).off('keyup', '.ember-inline-edit-input', this._handleKeyup)
+  }),
+
+  _disable: Ember.observer('enabled', function() {
+    if(!this.get('enabled')){
+      this.send('close');
+    }
   }),
 
   actions: {

--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -17,7 +17,7 @@ const {
 export default Ember.Component.extend({
   layout,
   classNames: ['ember-inline-edit'],
-  classNameBindings: ['isEditing:is-editing'],
+  classNameBindings: ['isEditing:is-editing', 'enabled::disabled'],
 
   textFields: ['search', 'url', 'text', 'phone', 'email', 'number'],
   textAreaFields: ['textarea'],

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,14 +2,17 @@ import Em from 'ember'
 
 export default Em.Controller.extend({
   value: '',
+  enabled: false,
 
   actions: {
     onSave () {
       console.log('Got save action');
     },
-
     onClose () {
       console.log('Got close action');
+    },
+    enable(){
+      this.toggleProperty('enabled');
     }
   }
 })

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,20 @@
-{{ember-inline-edit
-  showEditButton=true}}
+
+<div>
+  <div>Basic Usage</div>
+  {{ember-inline-edit value=value}}
+</div>
+<br /><br />
+
+<div>
+  <div>Edit Button</div>
+  {{ember-inline-edit value=value showEditButton=true}}
+</div>
+<br /><br />
+
+<div>
+  <div>Enabled/Disabled</div>
+  <button {{action 'enable'}}>{{enabled}}</button>
+  <br /><br />
+  {{ember-inline-edit value=value enabled=enabled}}
+</div>
+<br /><br />

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -170,3 +170,15 @@ test('it should send the close action if disabled', function (assert) {
   assert.equal(this.$('.ember-inline-edit-save').length, 0)
   assert.equal(this.get('value', 'closed'))
 })
+
+test('it should gain the .disabled class if not enabled', function (assert) {
+  this.set('enabled', true);
+  this.render(hbs`{{ember-inline-edit 
+                    enabled=enabled
+                    value=value}}`);
+
+  assert.equal(this.$('.ember-inline-edit:not(.disabled)').length, 1)
+
+  this.set('enabled', false);
+  assert.equal(this.$('.ember-inline-edit.disabled').length, 1)
+})

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -142,3 +142,31 @@ test('the text field is the same width as the original element', function(assert
     assert.equal(this.$('.ember-inline-edit-input').width(), width + 2)
 
 })
+
+test('on click, it does nothing if not enabled', function (assert) {
+  this.render(hbs`{{ember-inline-edit 
+                    enabled=false}}`);
+
+  assert.equal(this.$('.ember-inline-edit-input').length, 0)
+  assert.equal(this.$('.ember-inline-edit-save').length, 0)
+
+  this.$('.ember-inline-edit').click();
+  assert.equal(this.$('.ember-inline-edit-input').length, 0)
+  assert.equal(this.$('.ember-inline-edit-save').length, 0)
+})
+
+test('it should send the close action if disabled', function (assert) {
+  this.set('enabled', true);
+  this.render(hbs`{{ember-inline-edit 
+                    enabled=enabled
+                    value=value}}`);
+
+  this.$('.ember-inline-edit').click();
+  assert.equal(this.$('.ember-inline-edit-input').length, 1)
+  assert.equal(this.$('.ember-inline-edit-save').length, 1)
+
+  this.set('enabled', false);
+  assert.equal(this.$('.ember-inline-edit-input').length, 0)
+  assert.equal(this.$('.ember-inline-edit-save').length, 0)
+  assert.equal(this.get('value', 'closed'))
+})


### PR DESCRIPTION
Found a need for using ember-simple-auth's `session.isAuthenticated` to allow/disallow editing fields; this should permit that case.