### PR TITLE
Allow enter key on multiple inputs.

### DIFF
--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -21,6 +21,9 @@ export default Ember.Component.extend({
 
   textFields: ['search', 'url', 'text', 'phone', 'email', 'number'],
   textAreaFields: ['textarea'],
+  isMultiline: Ember.computed('field', 'textAreaFields', function(){
+    return this.get('textAreaFields').includes(this.get('field'));
+  }),
 
   isEditing: false,
 
@@ -63,10 +66,11 @@ export default Ember.Component.extend({
     const isEditing = get(this, 'isEditing')
     const isEnter = e.which === 13 || e.keyCode === 13
     const isEsc   = e.which === 27 || e.keyCode === 27
+    const isMultiline = this.get('isMultiline');
 
     if (!isEditing) { return }
 
-    if (isEnter) {
+    if (isEnter && !isMultiline) {
       this.send('save')
     } else if (isEsc) {
       this.send('close')

--- a/addon/templates/components/ember-inline-edit.hbs
+++ b/addon/templates/components/ember-inline-edit.hbs
@@ -7,7 +7,7 @@
         oninput={{action "setValue" value="target.value"}} 
         style={{fieldWidth}} />
 
-  {{else if (in-arr textAreaFields field)}}
+  {{else if isMultiline}}
     <textarea
       value={{value}}
       class="ember-inline-edit-input"

--- a/app/templates/components/ember-inline-edit.hbs
+++ b/app/templates/components/ember-inline-edit.hbs
@@ -7,7 +7,7 @@
         oninput={{action "setValue" value="target.value"}} 
         style={{fieldWidth}} />
 
-  {{else if (in-arr textAreaFields field)}}
+  {{else if isMultiline}}
     <textarea
       value={{value}}
       class="ember-inline-edit-input"

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -97,7 +97,7 @@ test('on save, it sends the save action', function (assert) {
   assert.equal(this.get('value'), 'Something')
 })
 
-test('on pressing enter, it sends the save action', function (assert) {
+test('on pressing enter in text field, it sends the save action', function (assert) {
   this.render(hbs`{{ember-inline-edit 
                         value=value 
                         onSave="onSave"
@@ -110,6 +110,22 @@ test('on pressing enter, it sends the save action', function (assert) {
   this.$('.ember-inline-edit-input').trigger('enter')
 
   assert.equal(this.get('value'), 'Something')
+})
+
+test('on pressing enter in textarea field, it does not send the save action', function (assert) {
+  this.render(hbs`{{ember-inline-edit 
+                    value=value
+                    field="textarea"
+                    onSave="onSave"
+                    onClose="onClose"}}`);
+
+  this.$('.ember-inline-edit').click()
+
+  this.$('.ember-inline-edit-input').val('Something')
+  this.$('.ember-inline-edit-input').trigger('input')
+  this.$('.ember-inline-edit-input').trigger('enter')
+
+  assert.equal(this.$('.ember-inline-edit-input').length, 1)
 })
 
 test('on pressing esc, it sends the close action', function (assert) {


### PR DESCRIPTION
Disabling keyboard auto-save behavior when dealing with multiline fields. Makes sense to me to allow multi-lines in a textarea.