### PR TITLE
Change width of inputs manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Editing can be conditionally prevented with the `enabled` property. When the com
     onSave='changeValue'}}
 ```
 
+By default, the width of the input is computed. If you want to set it on your
+own via css you can disable this feature:
+```handlebars
+  {{ember-inline-edit
+    value=value
+    computeWidth=false
+    onSave='changeValue'}}
+```
+
 There's no styling provided by default. Feel free to add your own.
 
 #### Keyboard Support

--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -32,6 +32,7 @@ export default Ember.Component.extend({
   placeholder: 'Not Provided',
   saveLabel: 'Save',
   fieldWidth: null,
+  computeWidth: true,
 
   valueIsEmpty: computed.empty('value'),
 
@@ -56,8 +57,10 @@ export default Ember.Component.extend({
     if(enabled) {
       if (isInside && !isEditing) {
         if (get(this, 'showEditButton')) { return }
-        let width = Ember.String.htmlSafe('width: ' + (editor.width() + 2) + 'px')
-        Ember.run(this, function(){ this.set('fieldWidth', width)})
+        if (get(this, 'computeWidth')){
+          let width = Ember.String.htmlSafe('width: ' + (editor.width() + 2) + 'px')
+          Ember.run(this, function(){ this.set('fieldWidth', width)})
+        }
         this.send('startEditing', e)
       } else if (!isInside && isEditing) {
         this.send('close')


### PR DESCRIPTION
I want to change the inputs via css:
```css
input[type="text"] {
  width: 80px;
}


```

One test introduced with #8 fails on my machine in both master branches. So I guess, this is not related.