### PR TITLE
Added condition to help hide the Save button entirely

### DIFF
--- a/addon/templates/components/ember-inline-editor.hbs
+++ b/addon/templates/components/ember-inline-editor.hbs
@@ -17,11 +17,13 @@
   {{/if}}
 {{/if}}
 
+{{#unless (eq saveLabel "hide")}}
 <button
   {{action attrs.on-save bubbles=false}}
   class="ember-inline-edit-save">
   {{saveLabel}}
 </button>
+{{/unless}}
 
 {{#if hintLabel}}
   <span class="hint">{{{hintLabel}}}</span>


### PR DESCRIPTION
This condition hides the Save button when the saveLabel is given as "hide"