### PR TITLE
Removes duplication for showCancelButton

### DIFF
--- a/tests/dummy/app/templates/appearance.hbs
+++ b/tests/dummy/app/templates/appearance.hbs
@@ -61,13 +61,6 @@
       </tr>
 
       <tr class="striped--near-white">
-        <td class="pa1">showCancelButton</td>
-        <td class="pa1 mid-gray code">Boolean</td>
-        <td class="pa1 mid-gray code">true</td>
-        <td class="pa1">Shows (or hides) the cancel button*</td>
-      </tr>
-
-      <tr class="striped--near-white">
         <td class="pa1">showEditButton</td>
         <td class="pa1 mid-gray code">Boolean</td>
         <td class="pa1 mid-gray code">false</td>


### PR DESCRIPTION
Hey @swastik... I just realized that there are 2 `showCancelButton` documentation in the table. This PR is to just removing one of them.