### PR TITLE
use children instead of childNodes

### DIFF
--- a/addon/components/ember-inline-editor.js
+++ b/addon/components/ember-inline-editor.js
@@ -26,7 +26,7 @@ export default Component.extend({
   },
 
   focusOnInput() {
-    const children = this.element.childNodes
+    const children = [...this.element.children]
 
     children.forEach(child => {
       if (isInputField(child)) child.focus()


### PR DESCRIPTION
Since `childNodes` doesn't exist in IE11, `this.element.childNodes` would break.

`[...this.element.children]` explanation:
- `this.element.children` returns a `NodeList` of the child nodes. This doesn't have the `forEach` method we have afterwards.
- we then spread into a new array `[...array]` to convert a `NodeList` to a normal array. Babel converts the spread into something equivalent that IE11 can run.
- we can now call `forEach` normally