### PR TITLE
On disable only Cancel if isEditing

### DIFF
--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -74,7 +74,7 @@ export default Component.extend({
   },
 
   didReceiveAttrs() {
-    if (this.enabled === false) {
+    if (this.enabled === false && this.isEditing) {
       this.send('cancel')
     }
   },


### PR DESCRIPTION
This was causing the value to be changed twice in the same runloop and thus was causing an Ember runtime error.