### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ember.js",
     "inline editing"
   ],
-  "repository": "",
+  "repository": "https://github.com/swastik/ember-inline-edit",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
This lets sites like Ember Observer get additional information about the addon.