### PR TITLE
Fix repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ember.js",
     "inline editing"
   ],
-  "repository": "",
+  "repository": "https://github.com/swastik/ember-inline-edit",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
Some of the score for Ember Observer is determined by having a correct repo url in package.json.
https://emberobserver.com/addons/ember-inline-edit
Click on `Hide This` under the score
This fixes that.