### PR TITLE
Add a `onOutsideClick` action

### DIFF
--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -61,7 +61,11 @@ export default Component.extend({
       this._setFieldWidth()
       this.send('startEditing', ev)
     } else if (!clickedInside && isEditing) {
-      this.send('cancel')
+      if (this.onOutsideClick) {
+        this.onOutsideClick()
+      } else {
+        this.send('cancel')
+      }
     }
   },
 

--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -62,7 +62,7 @@ export default Component.extend({
       this.send('startEditing', ev)
     } else if (!clickedInside && isEditing) {
       if (this.onOutsideClick) {
-        this.onOutsideClick()
+        this.onOutsideClick() && this.send('cancel')
       } else {
         this.send('cancel')
       }

--- a/addon/components/ember-inline-edit.js
+++ b/addon/components/ember-inline-edit.js
@@ -62,7 +62,7 @@ export default Component.extend({
       this.send('startEditing', ev)
     } else if (!clickedInside && isEditing) {
       if (this.onOutsideClick) {
-        this.onOutsideClick() && this.send('cancel')
+        this.onOutsideClick(this.value) && set(this, 'isEditing', false)
       } else {
         this.send('cancel')
       }

--- a/tests/dummy/app/templates/handling-actions.hbs
+++ b/tests/dummy/app/templates/handling-actions.hbs
@@ -24,7 +24,8 @@
       <p class="f6">
         If you want more control over this, you can use the <code>onOutsideClick</code> action. With this defined, <code>onCancel</code> will not be called
         when a user clicks outside the editor... instead, the editor will stay in the edit mode and you will get the <code>onOutsideClick</code>
-        action to handle it the way you want.
+        action with the current value to handle it the way you want. If you return a truthy value from the <code>onOutsideClick</code> action, the editor will be closed, otherwise
+        it will stay open.
       </p>
     </li>
   </ul>

--- a/tests/dummy/app/templates/handling-actions.hbs
+++ b/tests/dummy/app/templates/handling-actions.hbs
@@ -17,8 +17,14 @@
     <li>
       <code class="navy">onOutsideClick()</code> <small class="silver"> optional </small>
       <p class="f6">
-        When a user is in edit mode and clicks anywhere outside the editor, this action will be called if you've defined it.
-        If this is defined, <code>onCancel</code> action is not called on clicks outside the editor.
+        By default, when a user is in the edit mode and clicks anywhere outside the editor, <code>onCancel</code> is called and the editor
+        is closed.
+      </p>
+
+      <p class="f6">
+        If you want more control over this, you can use the <code>onOutsideClick</code> action. With this defined, <code>onCancel</code> will not be called
+        when a user clicks outside the editor... instead, the editor will stay in the edit mode and you will get the <code>onOutsideClick</code>
+        action to handle it the way you want.
       </p>
     </li>
   </ul>

--- a/tests/dummy/app/templates/handling-actions.hbs
+++ b/tests/dummy/app/templates/handling-actions.hbs
@@ -1,7 +1,7 @@
 <div class="introduction f5">
   <h6 class="ttu tracked">Handling Actions</h6>
 
-  <p>There are two actions that you can expect:</p>
+  <p>There are three actions that you can expect:</p>
 
   <ul>
     <li>
@@ -12,6 +12,14 @@
     <li>
       <code class="navy">onCancel()</code>
       <p class="f6">When a user clicks the Cancel button or hits the Esc key, you'll get the onCancel action with no arguments.</p>
+    </li>
+
+    <li>
+      <code class="navy">onOutsideClick()</code> <small class="silver"> optional </small>
+      <p class="f6">
+        When a user is in edit mode and clicks anywhere outside the editor, this action will be called if you've defined it.
+        If this is defined, <code>onCancel</code> action is not called on clicks outside the editor.
+      </p>
     </li>
   </ul>
 </div>

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -268,6 +268,36 @@ module('Integration | Component | ember inline edit', function(hooks) {
     assert.dom(classNames.input).exists('still in edit mode')
   })
 
+  test('on outside click, if `onOutsideClick` returns a truthy value, the editor is closed', async function(assert) {
+    assert.expect(5)
+
+    this.set('onOutsideClick', () => {
+      assert.ok(true, 'got the onOutsideClick action')
+      return true
+    })
+
+    this.set('onCancel', () => {
+      assert.ok(true, 'got the onCancel action')
+    })
+
+    await render(hbs`
+    {{ember-inline-edit
+      value=value
+      onOutsideClick=onOutsideClick
+      onCancel=onCancel}}
+
+    <div class="outside-element"></div>
+    `)
+
+    assert.dom(classNames.input).doesNotExist('does not start in edit mode')
+
+    await click(classNames.container)
+    assert.dom(classNames.input).exists('goes into edit mode')
+
+    await click('.outside-element')
+    assert.dom(classNames.input).doesNotExist('goes out of edit mode')
+  })
+
   test('the text field is the same width as the original element', async function(assert) {
     await render(hbs`{{ember-inline-edit
                         value='A long field value, probably at least a few hundred pixels'

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -269,7 +269,7 @@ module('Integration | Component | ember inline edit', function(hooks) {
   })
 
   test('on outside click, if `onOutsideClick` returns a truthy value, the editor is closed', async function(assert) {
-    assert.expect(5)
+    assert.expect(4)
 
     this.set('onOutsideClick', () => {
       assert.ok(true, 'got the onOutsideClick action')
@@ -277,7 +277,7 @@ module('Integration | Component | ember inline edit', function(hooks) {
     })
 
     this.set('onCancel', () => {
-      assert.ok(true, 'got the onCancel action')
+      assert.notOk(true, 'got the onCancel action but was not supposed to')
     })
 
     await render(hbs`

--- a/tests/integration/components/ember-inline-edit-test.js
+++ b/tests/integration/components/ember-inline-edit-test.js
@@ -215,6 +215,59 @@ module('Integration | Component | ember inline edit', function(hooks) {
     assert.notOk(find(classNames.input))
   })
 
+  test('on outside click, it sends the close action', async function(assert) {
+    assert.expect(4)
+
+    this.set('onCancel', () => {
+      assert.ok(true, 'got the onCancel action')
+    })
+
+    await render(hbs`
+    {{ember-inline-edit
+      value=value
+      onCancel=onCancel}}
+
+    <div class="outside-element"></div>
+    `)
+
+    assert.dom(classNames.input).doesNotExist('does not start in edit mode')
+
+    await click(classNames.container)
+    assert.dom(classNames.input).exists('goes into edit mode')
+
+    await click('.outside-element')
+    assert.dom(classNames.input).doesNotExist('goes out of edit mode')
+  })
+
+  test('on outside click, it calls `onOutsideClick` if provided', async function(assert) {
+    assert.expect(4)
+
+    this.set('onOutsideClick', () => {
+      assert.ok(true, 'got the onOutsideClick action')
+    })
+
+    this.set('onCancel', () => {
+      assert.ok(false, 'got the onCancel action but was not supposed to')
+    })
+
+    await render(hbs`
+    {{ember-inline-edit
+      value=value
+      onOutsideClick=onOutsideClick
+      onCancel=onCancel}}
+
+    <div class="outside-element"></div>
+    `)
+
+    assert.dom(classNames.input).doesNotExist('does not start in edit mode')
+
+    await click(classNames.container)
+    assert.dom(classNames.input).exists('goes into edit mode')
+
+    await click('.outside-element')
+    assert.dom(classNames.input).exists('still in edit mode')
+  })
+
   test('the text field is the same width as the original element', async function(assert) {
     await render(hbs`{{ember-inline-edit
                         value='A long field value, probably at least a few hundred pixels'


### PR DESCRIPTION
Fixes https://github.com/swastik/ember-inline-edit/issues/29

Right now, in edit mode, when a user clicks outside, we send the `onCancel` action and close the editor. The `onOutsideClick` action gives a little more control over that behavior. The caller can do what they want with it.